### PR TITLE
Added better checks for server whitelisting and error messages

### DIFF
--- a/pastures_integration/embed_helpers.py
+++ b/pastures_integration/embed_helpers.py
@@ -111,17 +111,22 @@ async def whitelist_remove(ip: str, key: str, username: str):
         username = username.lower()
         name = await minecraft_helpers.check_name(username)
         response = await minecraft_helpers.run_rcon_command(ip, key, f"whitelist remove {name}")
-        if not await minecraft_helpers.whitelist_remove_success(response):
-            raise RuntimeError(f"Player `{name}` was not whitelisted!")
+        await minecraft_helpers.whitelist_remove_success(response)
+
+        embed = customEmbed(title=f"Player removed from whitelist!",
+                            description=f":green_circle: Successfully removed player `{name}` from the whitelist!",
+                            timestamp=datetime.datetime.utcnow(),
+                            colour=0x7BC950).pastures_footer()
+        return embed
 
     except RuntimeError as err:
-        return await error_embed("Whitelist Error!", err)
 
-    embed = customEmbed(title=f"Player removed from whitelist!",
-                        description=f":green_circle: Successfully removed player `{name}` from the whitelist!",
-                        timestamp=datetime.datetime.utcnow(),
-                        colour=0x7BC950).pastures_footer()
-    return embed
+        # If the error needs to be formatted with the username
+        if "%s" in str(err):
+            return await error_embed("Whitelist Error!", str(err) % f"`{username}`")
+
+        # Else, just return the error
+        return await error_embed("Whitelist Error!", err)
 
 
 async def whitelist_add(ip: str, key: str, username: str):
@@ -129,17 +134,22 @@ async def whitelist_add(ip: str, key: str, username: str):
         username = username.lower()
         name = await minecraft_helpers.check_name(username)
         response = await minecraft_helpers.run_rcon_command(ip, key, f"whitelist add {name}")
-        if not await minecraft_helpers.whitelist_success(response):
-            raise RuntimeError(f"Player `{name}` already whitelisted!")
+
+        await minecraft_helpers.whitelist_success(response)
+
+        embed = customEmbed(title="Player Whitelisted!",
+                                description=f":green_circle:  Successfully whitelisted player `{name}`",
+                                timestamp=datetime.datetime.utcnow(),
+                                colour=0x7BC950).pastures_footer()
+        return embed
 
     except RuntimeError as err:
-        return await error_embed("Whitelist Error!", err)
+        # If the error needs to be formatted with the username
+        if "%s" in str(err):
+            return await error_embed("Whitelist Error!", str(err) % f"`{username}`")
 
-    embed = customEmbed(title="Player Whitelisted!",
-                        description=f":green_circle:  Successfully whitelisted player `{name}`",
-                        timestamp=datetime.datetime.utcnow(),
-                        colour=0x7BC950).pastures_footer()
-    return embed
+        # Else, just return the error
+        return await error_embed("Whitelist Error!", err)
 
 
 async def online_players(ip: str, key: str, message: str, color, image, text: str, words: list[str]):

--- a/pastures_integration/minecraft_helpers.py
+++ b/pastures_integration/minecraft_helpers.py
@@ -91,14 +91,21 @@ async def whitelist_success(response_string: str):
     if response_string.startswith("Added"):
         return True
     else:
-        return False
+        if response_string.startswith("Player"):
+            raise RuntimeError(f"Player %s is already whitelised!")
+        elif response_string.startswith("That player does not exist"):
+            raise RuntimeError(f"Player %s does not exist!")
 
 
 async def whitelist_remove_success(response_string: str):
     if response_string.startswith("Removed"):
         return True
     else:
-        return False
+        if response_string.startswith("Player"):
+            raise RuntimeError(f"Player %s is not whitelised!")
+        elif response_string.startswith("That player does not exist"):
+            raise RuntimeError(f"Player %s does not exist!")
+
 
 
 # Async Wrapper Function

--- a/pastures_integration/minecraft_helpers.py
+++ b/pastures_integration/minecraft_helpers.py
@@ -1,8 +1,7 @@
 import logging
 import aiomcrcon
 
-from mojang import API
-from mojang.api import MojangError
+import mojang
 
 log = logging.getLogger("red.mednis-cogs.pastures_integration")
 
@@ -34,15 +33,20 @@ async def player_count(response_string: str):
 
 # Functions for dealing with username resolution
 async def check_name(input: str):
-    api = API()
+    api = mojang.API()
     try:
         uuid = api.get_uuid(input)
         if not uuid:
             raise RuntimeError(f"Could not find user `{input}` from mojang!")
         return api.get_username(uuid)
-    except MojangError:
-        raise RuntimeError(f"Error connecting to mojang api!")
-
+    except mojang.errors.MojangError as err:
+        logging.error(f"Error occurred while trying to resolve the username `{input}`: {err}")
+        if "HTTP 429" in str(err):
+            raise RuntimeError("Mojang API rate limit reached! \n\nCool it down and try again in a bit..")
+        elif "HTTP 404" in str(err):
+            raise RuntimeError(f"Could not find user `{input}`. \n\nEither the username does not exist or you misstyped it.")
+        else:
+            raise RuntimeError(f"Mojang API call failed to find `{input}`. \nA unknwon error occoured.")
 
 async def split_names(input: str):
     input.strip(" ")


### PR DESCRIPTION
This improves the error messages around failed whitelists.
It now makes failed name lookups that return in a 404 obvious, instead of just reporting "Error connecting to the Mojang API"
It also fixes some potential issues with server whitelist response handling, since the end result of the actions on the server are what are important.

:D